### PR TITLE
handle temp locations

### DIFF
--- a/Catalog.lua
+++ b/Catalog.lua
@@ -684,8 +684,13 @@ function PopulateItemsDataSources( response, itemsDataTable )
         itemRow = SetItemNodeFromXML(itemRow, bibData["mms_id"], "ReferenceNumber");
         itemRow = SetItemNodeFromXML(itemRow, holdingData["holding_id"], "HoldingId");
         itemRow = SetItemNodeFromXML(itemRow, holdingData["call_number"], "CallNumber");
-        itemRow = SetItemNodeFromCustomizedMapping(itemRow, itemData["location"], "Location", CustomizedMapping.Locations);
-        itemRow = SetItemNodeFromXML(itemRow, itemData["library"], "Library");
+        if (holdingData["in_temp_location"].InnerXml == "true") then
+            itemRow = SetItemNodeFromCustomizedMapping(itemRow, holdingData["temp_location"], "location", CustomizedMapping.Locations);
+            itemRow = SetItemNodeFromXML(itemRow, holdingData["temp_library"], "library");
+        else
+            itemRow = SetItemNodeFromCustomizedMapping(itemRow, itemData["location"], "Location", CustomizedMapping.Locations);
+            itemRow = SetItemNodeFromXML(itemRow, itemData["library"], "Library");
+        end;
         itemRow = SetItemNodeFromXML(itemRow, itemData["barcode"], "Barcode");
         itemRow = SetItemNodeFromXML(itemRow, itemData["description"], "Description");
 


### PR DESCRIPTION


### Why these changes are being introduced

Temporary location information was not being imported into the Aeon record

### How this addresses that need

Added logic to the add on to check for and import temporary location and library information

### Side effects of this change

none
### Relevant ticket(s)
https://mitlibraries.atlassian.net/jira/servicedesk/projects/ES/queues/custom/16/ES-3017